### PR TITLE
Use (?s) option in RewriteRules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
     RewriteRule  ^$ public/    [L]
-    RewriteRule  (.*) public/$1 [L]
+    RewriteRule  ((?s).*) public/$1 [L]
 </IfModule>

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -3,5 +3,5 @@ AddDefaultCharset UTF-8
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php?_url=/$1 [QSA,L]
+    RewriteRule ^((?s).*)$ index.php?_url=/$1 [QSA,L]
 </IfModule>


### PR DESCRIPTION
The reason for doing this is that apparently some Apache binaries
are distributed linked to a PCRE library that considers character
0x85 a new line like character. On such Apache instances, the
redirect rules without (?s) will not work for URLs containing
characters that have a 0x85 byte in their UTF-8 expansion.
